### PR TITLE
Disables the rendering of the annotation layer, which houses links. T…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Disabled rendering of PDF links
+
 ## [1.0.2] - 2024-05-25
 
 ### Changed

--- a/app/_components/pdf-viewer.tsx
+++ b/app/_components/pdf-viewer.tsx
@@ -150,6 +150,7 @@ export default function PdfViewer({
                     renderTextLayer={true}
                     canvasBackground="#ccc"
                     onLoadSuccess={onPageLoadSuccess}
+                    renderAnnotationLayer={false}
                   />
                 </RenderContext.Provider>
               )}


### PR DESCRIPTION
…his may need testing to verify that we aren't removing something that should be there. According to this article https://www.gonitro.com/user-guide/pro/article/annotation-layer-and-content-layer, the content layer should be where all the pattern data is. There may be a way to disable this with more precision if we have access to custom css (do we manage non-tailwind css anywhere?). This was also the recommended method (roughly) from the pdfjs project itself. https://github.com/mozilla/pdf.js/issues/10664

## Pull Request Checklist

- [ ] I have run `yarn build` to ensure that the project builds successfully.
- [ ] I have updated `CHANGELOG.md` with the necessary changes made in this pull request.

## Description

<!-- Provide a brief description of the changes made in this pull request -->

## Related Issues

<!-- List any related issues or pull requests -->

## TODO

<!-- List tasks to complete before merging -->
